### PR TITLE
[WIP] #4 環境変数の書き出し

### DIFF
--- a/vdotenv.v
+++ b/vdotenv.v
@@ -16,6 +16,20 @@ pub fn over_load() {
     load_file(filename, true)
 }
 
+// .envファイルに記載されている環境変数の設定状況をターミナルに表示する
+fn print_terminal() {
+    filename := '.env'
+    contents := os.read_file(filename.trim_space()) or {
+        println('Failed to open $filename')
+        return
+    }
+    lines := contents.split_into_lines()
+    file_env_map := parse_lines(lines)
+    keys := file_env_map.keys()
+    os_env_map := load_env_var(keys)
+    println(format_env_map(os_env_map))
+}
+
 fn load_file(filename string, over_load bool) {
     contents := os.read_file(filename.trim_space()) or {
         println('Failed to open $filename')
@@ -30,6 +44,15 @@ fn load_file(filename string, over_load bool) {
     }
 }
 
+// 引数で渡されたキーに紐づく環境変数を keys and values で返却する.
+fn load_env_var(keys []string) map[string]string{
+    mut env_map := map[string]string {}
+    for key in keys {
+        env_map[key] = os.getenv(key)
+    }
+    return env_map
+}
+
 // env file から読み込んだ値を keys and values で返却する.
 fn parse_lines(lines []string) map[string]string {
     mut env_map := map[string]string{}
@@ -39,4 +62,13 @@ fn parse_lines(lines []string) map[string]string {
         env_map[key] = value
     }
     return env_map 
+}
+
+// keys and values で渡された値をkey=valueにフォーマットする
+fn format_env_map(env_map map[string]string) string {
+    mut format_string := ''
+    for key in env_map.keys() {
+        format_string += '$key=${env_map[key]}\n'
+    }
+    return format_string
 }


### PR DESCRIPTION
- 処理の責務を意識してload_fileを分割した
    - ついでに関数の順番をpub fn,os.<hoge>でのやりとり,データ処理関係の順に並べてみた．
- OSの環境変数の読み込みを実装
- map[string]stringのフォーマッタを実装
- ターミナルへの出力を実装
- ファイルへの出力を実装