### PR TITLE
Add .env comment support and test

### DIFF
--- a/vdotenv.v
+++ b/vdotenv.v
@@ -68,7 +68,7 @@ fn read_file(filename string) string {
 }
 
 // fileに書き出す
-fn write_file(filename, contents string) {
+fn write_file(filename string, contents string) {
 	write_filename := './$filename.trim_space() $time.now()'
 	os.write_file(write_filename, contents) or {
 		println('Failed to open $write_filename')
@@ -96,10 +96,29 @@ fn parse_lines(lines []string) map[string]string {
 	mut env_map := map[string]string{}
 	for line in lines {
 		if !line.starts_with('#') {
-			key := line.split('=')[0]
-			temp_value := line.split('=')[1]
+			segments_between_hashes := line.split('#')
+			mut quotes_are_open := false
+			mut segments_to_keep := []string{}
+			for segment in segments_between_hashes {
+				if segment.count('"') == 1 || segment.count('\'') == 1 {
+					if quotes_are_open {
+						quotes_are_open = false
+						segments_to_keep << segment
+					} else {
+						quotes_are_open = true
+					}
+				}
 
-			value := temp_value.split(' #')[0]
+				if segments_to_keep.len == 0 || quotes_are_open {
+					segments_to_keep << segment
+				}
+			}
+
+			mut new_line := segments_to_keep.join('#')
+
+			key := new_line.split('=')[0].trim_space()
+			value := new_line.split('=')[1].trim_space()
+			
 			env_map[key] = value
 		}
 	}

--- a/vdotenv.v
+++ b/vdotenv.v
@@ -95,9 +95,13 @@ fn parse_contents(contents string) map[string]string {
 fn parse_lines(lines []string) map[string]string {
 	mut env_map := map[string]string{}
 	for line in lines {
-		key := line.split('=')[0]
-		value := line.split('=')[1]
-		env_map[key] = value
+		if !line.starts_with('#') {
+			key := line.split('=')[0]
+			temp_value := line.split('=')[1]
+
+			value := temp_value.split(' #')[0]
+			env_map[key] = value
+		}
 	}
 	return env_map
 }

--- a/vdotenv.v
+++ b/vdotenv.v
@@ -100,7 +100,7 @@ fn parse_lines(lines []string) map[string]string {
 			mut quotes_are_open := false
 			mut segments_to_keep := []string{}
 			for segment in segments_between_hashes {
-				if segment.count('"') == 1 || segment.count('\'') == 1 {
+				if segment.count('"') == 1 || segment.count("\'") == 1 {
 					if quotes_are_open {
 						quotes_are_open = false
 						segments_to_keep << segment
@@ -108,17 +108,13 @@ fn parse_lines(lines []string) map[string]string {
 						quotes_are_open = true
 					}
 				}
-
 				if segments_to_keep.len == 0 || quotes_are_open {
 					segments_to_keep << segment
 				}
 			}
-
 			mut new_line := segments_to_keep.join('#')
-
 			key := new_line.split('=')[0].trim_space()
 			value := new_line.split('=')[1].trim_space()
-			
 			env_map[key] = value
 		}
 	}

--- a/vdotenv_test.v
+++ b/vdotenv_test.v
@@ -5,9 +5,13 @@ import os
 /*
 Sample .env file for tests:
 
-#TEST3=NOLOADENV
-TEST2=LOADENV #TEST4=NOLOADENV
 TEST=OVERLOADENV
+TEST2=LOADENV
+#TEST3=NOLOADENV
+TEST4=NOHASH#COMMENTSTARTSHERe
+TEST5=NOHASH #TEST6=NOLOADENV
+TEST7 = "HASH #ENV" # COMMENT
+
 */
 
 fn test_load() {
@@ -24,13 +28,26 @@ fn test_over_load() {
 	assert env_var == 'OVERLOADENV'
 }
 
-fn test_comments() {
-	// loads env vars and verifies that comments that start a line
-	// or have a space followed by # (' #') are ignored
+fn test_comments_start_line() {
+	// loads env vars and verifies that comments that start a line are ignored
 	load()
 	env_var := os.getenv('TEST3')
 	assert env_var == ''
+}
 
-	env_var2 := os.getenv('TEST4')
-	assert env_var2 == ''
+fn test_comments_end_line() {
+	load()
+	// loads env vars and verifies that comments are removed from the end of values
+	env_var := os.getenv('TEST4')
+	assert env_var == 'NOHASH'
+
+	env_var2 := os.getenv('TEST5')
+	assert env_var2 == 'NOHASH'
+}
+
+fn test_quoted_hash() {
+	load()
+	// load env vars and verify comments are ignored without affecting hashes within quotes 
+	env_var := os.getenv('TEST7')
+	assert env_var == '\"HASH #ENV\"'
 }

--- a/vdotenv_test.v
+++ b/vdotenv_test.v
@@ -11,9 +11,7 @@ TEST2=LOADENV
 TEST4=NOHASH#COMMENTSTARTSHERe
 TEST5=NOHASH #TEST6=NOLOADENV
 TEST7 = "HASH #ENV" # COMMENT
-
 */
-
 fn test_load() {
 	// loads env vars from a .env file.
 	load()
@@ -40,14 +38,13 @@ fn test_comments_end_line() {
 	// loads env vars and verifies that comments are removed from the end of values
 	env_var := os.getenv('TEST4')
 	assert env_var == 'NOHASH'
-
 	env_var2 := os.getenv('TEST5')
 	assert env_var2 == 'NOHASH'
 }
 
 fn test_quoted_hash() {
 	load()
-	// load env vars and verify comments are ignored without affecting hashes within quotes 
+	// load env vars and verify comments are ignored without affecting hashes within quotes
 	env_var := os.getenv('TEST7')
 	assert env_var == '\"HASH #ENV\"'
 }

--- a/vdotenv_test.v
+++ b/vdotenv_test.v
@@ -2,6 +2,14 @@ module vdotenv
 
 import os
 
+/*
+Sample .env file for tests:
+
+#TEST3=NOLOADENV
+TEST2=LOADENV #TEST4=NOLOADENV
+TEST=OVERLOADENV
+*/
+
 fn test_load() {
 	// loads env vars from a .env file.
 	load()
@@ -14,4 +22,15 @@ fn test_over_load() {
 	over_load()
 	env_var := os.getenv('TEST')
 	assert env_var == 'OVERLOADENV'
+}
+
+fn test_comments() {
+	// loads env vars and verifies that comments that start a line
+	// or have a space followed by # (' #') are ignored
+	load()
+	env_var := os.getenv('TEST3')
+	assert env_var == ''
+
+	env_var2 := os.getenv('TEST4')
+	assert env_var2 == ''
 }


### PR DESCRIPTION
This adds support for
```
#TEST3=NOLOADENV
TEST2=LOADENV #TEST4=NOLOADENV
TEST=OVERLOADENV
```

Does dotenv support
```
TEST2=LOADENV#TEST4=NOLOADENV
```
I can work on this, but I'd have to recommend that this is only allowed if the value (LOADENV here) is quoted.

I also have another PR open; if you're ok with both, let me know and I can merge them together into a single one if it's easier.